### PR TITLE
Implement config option 'size' to specify font family to be used

### DIFF
--- a/MMM-TomTomCalculateRouteTraffic.js
+++ b/MMM-TomTomCalculateRouteTraffic.js
@@ -5,6 +5,25 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 		refresh: (5 * 60 * 1000),
 		animationSpeed: 2000,
 		routes: [],
+		size: "medium",
+	},
+
+	adjustedFontClassMap: {
+		"small": {
+			"small": "xsmall",
+			"medium": "small",
+			"large": "medium",
+		},
+		"medium": {
+			"small": "small",
+			"medium": "medium",
+			"large": "large",
+		},
+		"large": {
+			"small": "medium",
+			"medium": "large",
+			"large": "xlarge",
+		},
 	},
 
 	start: function () {
@@ -58,18 +77,18 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 
 			let timeDiv = document.createElement("div");
 			let numbersSpan = document.createElement("span");
-			numbersSpan.className = "bright large";
+			numbersSpan.className = "bright " + this.getAdjustedFontClass("large");
 			numbersSpan.innerHTML = calculatedRoute.calculated.timeMin;
 			timeDiv.appendChild(numbersSpan);
 			let minutesSpan = document.createElement("span");
-			minutesSpan.className = "normal medium";
+			minutesSpan.className = "normal " + this.getAdjustedFontClass("medium");
 			minutesSpan.innerHTML = " " + this.translate("minutes");
 			timeDiv.appendChild(minutesSpan);
 			travelDiv.appendChild(timeDiv);
 			if (calculatedRoute.calculated.delayMin > 0) {
 				let delayDiv = document.createElement("div");
 				delayDiv.innerHTML = "(" + this.translate("including minutes delay", {"delayInMinutes": calculatedRoute.calculated.delayMin}) + ")";
-				delayDiv.className = "medium delay";
+				delayDiv.className = "delay " + this.getAdjustedFontClass("medium");
 				travelDiv.appendChild(delayDiv);
 			}
 
@@ -82,7 +101,7 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 				infoDiv.appendChild(symbolSpan);
 			}
 			let nameSpan = document.createElement("span");
-			nameSpan.className = "normal small";
+			nameSpan.className = "normal " + this.getAdjustedFontClass("small");
 			nameSpan.innerHTML = calculatedRoute.route.name + " (" + calculatedRoute.calculated.lengthKm + " km)";
 			infoDiv.appendChild(nameSpan);
 
@@ -137,6 +156,10 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 			}
 		};
 		this.calculatedRoutes.push(calculatedRoute);
+	},
+
+	getAdjustedFontClass: function (fontSizeClass) {
+		return this.adjustedFontClassMap[this.config.size][fontSizeClass];
 	},
 
 });

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ modules: [
       apiTomTomKey: "<YOUR_API_KEY_HERE>",
       refresh: (5 * 60 * 1000), // in milliseconds
       animationSpeed: 2000, // in milliseconds
+      size: "medium",
       routes: [{
         name: "Lausanne City Center",
         symbol: "city",
@@ -50,6 +51,7 @@ modules: [
 | `routes `         | `true`   | Routes definition, with an array. See `route` specs below |                               |
 | `refresh `        | `false`  | Refresh interval (in milliseconds)                        | `(5 * 60 * 1000)` (5 minutes) |
 | `animationSpeed ` | `false`  | Animation time to display results (in milliseconds)       | `2000`                        |
+| `size `           | `false`  | Font size family. Could be `small`, `medium` or `large`   | `medium`                      |
 
 ### `route` specs
 


### PR DESCRIPTION
Change request reported in #2 .

Size option examples:

1. `medium` (default)
![image](https://github.com/user-attachments/assets/e1b9de2e-e3a3-4152-9c04-53e49de0daea)

2. 'small'
![image](https://github.com/user-attachments/assets/f8fa4f88-6a94-49af-8675-b7281cd23476)

3. 'large'
![image](https://github.com/user-attachments/assets/a257d494-9bb5-4e7d-8ab4-7ef9b67d2098)
