### PR TITLE
Reset old error message in calculateRoutes

### DIFF
--- a/MMM-TomTomCalculateRouteTraffic.js
+++ b/MMM-TomTomCalculateRouteTraffic.js
@@ -113,6 +113,9 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 	},
 
 	calculateRoutes: function () {
+		// Reset the error message
+		this.errorMessage = undefined;
+
 		this.calculatedRoutes = [];
 		this.config.routes.forEach(route => {
 			this.calculateRoute(route);


### PR DESCRIPTION
Before this change, any single error would keep displaying repeatedly, meaning that just one failed request required a full MagicMirror restart.