### PR TITLE
Show delay

### DIFF
--- a/MMM-TomTomCalculateRouteTraffic.js
+++ b/MMM-TomTomCalculateRouteTraffic.js
@@ -6,6 +6,7 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 		animationSpeed: 2000,
 		routes: [],
 		size: "medium",
+		showDelay: true,
 	},
 
 	adjustedFontClassMap: {
@@ -86,7 +87,7 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 			minutesSpan.innerHTML = " " + this.translate("minutes");
 			timeDiv.appendChild(minutesSpan);
 			travelDiv.appendChild(timeDiv);
-			if (calculatedRoute.calculated.delayMin > 0) {
+			if (this.config.showDelay && calculatedRoute.calculated.delayMin > 0) {
 				let delayDiv = document.createElement("div");
 				delayDiv.innerHTML = "(" + this.translate("including minutes delay", {"delayInMinutes": calculatedRoute.calculated.delayMin}) + ")";
 				delayDiv.className = "delay " + this.getAdjustedFontClass("medium");

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ modules: [
       refresh: (5 * 60 * 1000), // in milliseconds
       animationSpeed: 2000, // in milliseconds
       size: "medium",
+      showDelay: true,
       routes: [{
         name: "Lausanne City Center",
         symbol: "city",

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ modules: [
 | `refresh `        | `false`  | Refresh interval (in milliseconds)                        | `(5 * 60 * 1000)` (5 minutes) |
 | `animationSpeed ` | `false`  | Animation time to display results (in milliseconds)       | `2000`                        |
 | `size `           | `false`  | Font size family. Could be `small`, `medium` or `large`   | `medium`                      |
+| `showDelay `      | `false`  | Show or hide delay time in route info                     | `true`                        |
 
 ### `route` specs
 


### PR DESCRIPTION
Add config option showDelay to toggle display of delay time. Allows users to hide delay information if preferred.