### PR TITLE
Feature/use metrics or imperial units

### DIFF
--- a/MMM-TomTomCalculateRouteTraffic.js
+++ b/MMM-TomTomCalculateRouteTraffic.js
@@ -107,7 +107,7 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 			let nameSpan = document.createElement("span");
 			nameSpan.className = "normal " + this.getAdjustedFontClass("small");
 			let lengthInfo = calculatedRoute.calculated.lengthKm + " km";
-			if (this.getUnits() === "imperial") {
+			if (this.config.units === "imperial") {
 				lengthInfo = calculatedRoute.calculated.lengthMiles + " mi";
 			}
 			nameSpan.innerHTML = calculatedRoute.route.name + " (" + lengthInfo + ")";
@@ -171,9 +171,5 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 	getAdjustedFontClass: function (fontSizeClass) {
 		return this.adjustedFontClassMap[this.config.size][fontSizeClass];
 	},
-
-	getUnits: function () {
-		return this.config.units === "imperial" ? "imperial" : "metric";
-	}
 
 });

--- a/MMM-TomTomCalculateRouteTraffic.js
+++ b/MMM-TomTomCalculateRouteTraffic.js
@@ -105,7 +105,11 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 			}
 			let nameSpan = document.createElement("span");
 			nameSpan.className = "normal " + this.getAdjustedFontClass("small");
-			nameSpan.innerHTML = calculatedRoute.route.name + " (" + calculatedRoute.calculated.lengthKm + " km)";
+			let lengthInfo = calculatedRoute.calculated.lengthKm + " km";
+			if (this.getUnits() === "imperial") {
+				lengthInfo = calculatedRoute.calculated.lengthMiles + " mi";
+			}
+			nameSpan.innerHTML = calculatedRoute.route.name + " (" + lengthInfo + ")";
 			infoDiv.appendChild(nameSpan);
 
 			wrapper.appendChild(routeDiv);
@@ -155,6 +159,7 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 			route: route,
 			calculated: {
 				lengthKm: Math.ceil(summary.lengthInMeters / 1000),
+				lengthMiles: Math.ceil(summary.lengthInMeters / 1609.344),
 				timeMin: Math.ceil(summary.travelTimeInSeconds / 60),
 				delayMin: Math.ceil(summary.trafficDelayInSeconds / 60),
 			}
@@ -165,5 +170,9 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 	getAdjustedFontClass: function (fontSizeClass) {
 		return this.adjustedFontClassMap[this.config.size][fontSizeClass];
 	},
+
+	getUnits: function () {
+		return this.config.units === "imperial" ? "imperial" : "metric";
+	}
 
 });

--- a/MMM-TomTomCalculateRouteTraffic.js
+++ b/MMM-TomTomCalculateRouteTraffic.js
@@ -7,6 +7,7 @@ Module.register("MMM-TomTomCalculateRouteTraffic", {
 		routes: [],
 		size: "medium",
 		showDelay: true,
+		units: config.units,
 	},
 
 	adjustedFontClassMap: {

--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ modules: [
 
 ### Options
 
-| Field             | Required | Description                                               | Default                       |
-|-------------------|----------|-----------------------------------------------------------|-------------------------------|
-| `apiTomTomKey`    | `true`   | Your API key for TomTom API                               |                               |
-| `routes `         | `true`   | Routes definition, with an array. See `route` specs below |                               |
-| `refresh `        | `false`  | Refresh interval (in milliseconds)                        | `(5 * 60 * 1000)` (5 minutes) |
-| `animationSpeed ` | `false`  | Animation time to display results (in milliseconds)       | `2000`                        |
-| `size `           | `false`  | Font size family. Could be `small`, `medium` or `large`   | `medium`                      |
-| `showDelay `      | `false`  | Show or hide delay time in route info                     | `true`                        |
+| Field             | Required | Description                                                        | Default                          |
+|-------------------|----------|--------------------------------------------------------------------|----------------------------------|
+| `apiTomTomKey`    | `true`   | Your API key for TomTom API                                        |                                  |
+| `routes `         | `true`   | Routes definition, with an array. See `route` specs below          |                                  |
+| `refresh `        | `false`  | Refresh interval (in milliseconds)                                 | `(5 * 60 * 1000)` (5 minutes)    |
+| `animationSpeed ` | `false`  | Animation time to display results (in milliseconds)                | `2000`                           |
+| `size `           | `false`  | Font size family. Could be `small`, `medium` or `large`            | `medium`                         |
+| `showDelay `      | `false`  | Show or hide delay time in route info                              | `true`                           |
+| `units`           | `false`  | Units for distance. Values can be `metric` (km) or `imperial` (mi) | Value from global config `units` |
 
 ### `route` specs
 


### PR DESCRIPTION
Add option to use `metrics` (km) or `imperial` (mi) as distance units. 

Based on the proposal by @ant-garz, in #9, but simplified to rely on the default global `units` config, which can be overridden though.
